### PR TITLE
feat: update outdated deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   "devDependencies": {
     "@angular/compiler": "~4.3.1",
     "@angular/compiler-cli": "~4.3.1",
-    "@ngtools/webpack": "1.3.3",
+    "@ngtools/webpack": "1.5.3",
     "@types/express": "^4.0.36",
     "@types/jasmine": "^2.5.53",
     "@types/lodash": "4.14.55",


### PR DESCRIPTION
Actually ngtools/webpack version is set to 1.3.3 in package.json, perhaps it was set to 1.5.3 in package-lock.json

With version 1.3.3, aotPlugin does not work properly, ngtools/webpack must be upgraded to 1.5.3.

Related issues with 1.3.3 could be reproduced by doing : 

- delete package-lock.json
- remove node_modules
- npm install
- npm run build:universal-prod