### PR TITLE
fix(config): fix e2e moduleNameMapper

### DIFF
--- a/tools/test/e2e-preset.json
+++ b/tools/test/e2e-preset.json
@@ -12,12 +12,8 @@
   },
   "testRegex": "(/__tests__/.*|\\.(test|e2e-spec))\\.(ts|js)$",
   "moduleNameMapper": {
-    "~(.*)$": "<rootDir>/src/client/$1",
+    "~(.*)$": "<rootDir>/src$1",
     "^e2e-config$": "<rootDir>/tools/test/nightmare.config.ts"
   },
-  "moduleFileExtensions": [
-    "ts",
-    "js",
-    "html"
-  ]
+  "moduleFileExtensions": ["ts", "js", "html"]
 }


### PR DESCRIPTION
test: fix e2e test moduleNameMapper config

When run yarn e2e, it reports error due to mismatched path#